### PR TITLE
fix: Correct dependencies for Alpine Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,23 @@
 # This stage installs build-time dependencies and compiles the Python packages.
 FROM python:3.9-alpine as builder
 
+# Enable the community repository for more packages
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
 # Install build-time system dependencies for the Python packages
-# This includes compilers and development headers.
+# This includes compilers, headers, and development libraries.
 RUN apk add --no-cache \
     build-base \
     cmake \
     linux-headers \
-    lapack-dev \
+    gfortran \
+    openblas-dev \
     freetype-dev \
     pkgconfig \
     jpeg-dev \
     zlib-dev \
+    tiff-dev \
+    libpng-dev \
     qt5-qtbase-dev
 
 # Create a virtual environment for clean dependency management
@@ -22,19 +28,23 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy and install Python packages into the virtual environment
 COPY requirements.txt .
-# We specify the build options for PyQt5 to ensure it finds Qt.
 RUN pip install --no-cache-dir -r requirements.txt
 
 # ---- Final Stage ----
 # This stage creates the final, lightweight image.
 FROM python:3.9-alpine
 
+# Enable the community repository for runtime packages
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
 # Install only the run-time system dependencies
 RUN apk add --no-cache \
-    lapack \
+    openblas \
     freetype \
     libjpeg-turbo \
-    qt5-qtbase
+    tiff \
+    libpng \
+    qt5-libs
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
This commit fixes a build failure in the `alpine`-based Dockerfile. The previous version was missing some system-level dependencies and did not have the community repository enabled, causing the `apk add` command to fail.

Changes:
- Enabled the Alpine 'community' repository to ensure all required packages can be found.
- Added a more comprehensive list of build-time dependencies (`gfortran`, `openblas-dev`, etc.) to correctly compile the scientific Python stack.
- Added the corresponding run-time libraries to the final image stage.

This should resolve the `apk` error (exit code 99) and allow the Docker image to be built successfully.