### PR TITLE
fix: Correct Qt5 runtime dependency in Alpine Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apk add --no-cache \
     libjpeg-turbo \
     tiff \
     libpng \
-    qt5-libs
+    qt5-qtbase
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
This commit fixes a build failure in the final stage of the `alpine`-based Dockerfile. The `apk add` command was failing because the package `qt5-libs` does not exist.

The package name has been corrected to `qt5-qtbase`, which is the correct package for the Qt5 core runtime libraries on Alpine Linux.

This should resolve the final build error and produce a working, lightweight Docker image.