### PR TITLE
Fix `ModuleNotFoundError` with relative import in main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ import sys
 import os
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import Qt
-from gui.main_window import MainWindow
+from .gui.main_window import MainWindow
 
 def main():
     app = QApplication(sys.argv)


### PR DESCRIPTION
This commit fixes a `ModuleNotFoundError: No module named 'gui'` that occurred when running the application as a module.

The `src/main.py` script was using a direct import (`from gui.main_window...`), which fails when `src` is treated as a package. The import has been changed to a relative import (`from .gui.main_window...`) to correctly locate the `gui` module within the `src` package.

This fix is a follow-up to the previous commit that enabled module-based execution. With this change, the application's package structure is now consistent and the import errors should be fully resolved.