### PR TITLE
Fix Qt platform plugin error by adding dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libegl1-mesa \
     libxkbcommon-x11-0 \
     libxcb1-dev \
+    libxcb-xinerama0 \
+    libxcb-shape0 \
+    libxcb-randr0 \
+    libxcb-render0 \
+    libxcb-image0 \
+    libxcb-keysyms1 \
+    libxcb-icccm4 \
     # User-requested
     libpq-dev \
     # Clean up apt cache to save space


### PR DESCRIPTION
This commit fixes a runtime error: `qt.qpa.plugin: Could not load the Qt platform plugin "xcb"`.

This error occurs when the Qt application cannot find or load the necessary system libraries for rendering graphics. Although some dependencies were present, several key `libxcb` packages were missing.

This commit updates the `Dockerfile` to include the following system packages in the `apt-get install` command:
- `libxcb-xinerama0`
- `libxcb-shape0`
- `libxcb-randr0`
- `libxcb-render0`
- `libxcb-image0`
- `libxcb-keysyms1`
- `libxcb-icccm4`

Adding these dependencies should resolve the plugin loading issue and allow the GUI application to start correctly within the Docker container.