### PR TITLE
fix: Resolve frontend compilation errors

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,16 +10,22 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-slot": "^1.1.0",
     "@tanstack/react-query": "^5.85.3",
     "axios": "^1.11.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
     "konva": "^9.3.22",
     "lucide-react": "^0.540.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-konva": "^19.0.7",
-    "recharts": "^3.1.2"
+    "recharts": "^3.1.2",
+    "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
+    "tailwindcss-animate": "^1.0.7",
     "@eslint/js": "^9.33.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,11 +1,77 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
+  darkMode: ["class"],
   content: [
-    "./index.html",
-    "./src/**/*.{js,ts,jsx,tsx}",
-  ],
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}',
+	],
+  prefix: "",
   theme: {
-    extend: {},
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
   },
-  plugins: [],
+  plugins: [require("tailwindcss-animate")],
 }


### PR DESCRIPTION
This commit addresses critical issues that caused the frontend application to fail during compilation. The errors stemmed from the manual setup of `shadcn/ui` which was necessary due to environment issues with `npx`.

The following corrections have been made:

1.  **Add Missing Dependencies to `package.json`**:
    -   Added `@radix-ui/react-slot` and `@radix-ui/react-dropdown-menu` for core component functionality.
    -   Added `clsx` and `tailwind-merge` for utility class composition.
    -   Added `class-variance-authority` as a core peer dependency for `shadcn/ui`.
    -   Added `tailwindcss-animate` to enable animations.

2.  **Update Tailwind CSS Configuration**:
    -   The `tailwind.config.js` file has been updated to the full configuration expected by `shadcn/ui`.
    -   This includes defining the full color palette, border radius, and animation keyframes, and registering the `tailwindcss-animate` plugin.

These changes should ensure that all necessary packages are installed during `npm install` and that the Tailwind CSS and component styles are generated correctly, allowing the Vite build process to complete successfully.