### PR TITLE
fix(frontend): Add missing react-dropzone dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "lucide-react": "^0.363.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-dropzone": "^14.2.3",
     "react-konva": "^18.2.10",
     "recharts": "^2.12.3",
     "tailwind-merge": "^2.2.2"


### PR DESCRIPTION
The frontend build was failing because the `react-dropzone` package was used without being declared as a dependency in `package.json`.

This change adds the `react-dropzone` package to the dependencies, which resolves the build error.