### PR TITLE
feat: Build custom nginx image instead of using volume mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,9 @@ services:
     restart: unless-stopped
 
   nginx:
-    image: nginx:latest
+    build: ./nginx
     ports:
       - "8080:80"
-    volumes:
-      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
     depends_on:
       - frontend
       - backend

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:1.23-alpine
+COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This implements a much cleaner approach for the Nginx configuration based on a user suggestion.

Instead of using the stock `nginx:latest` image and mounting configuration files at runtime, this change introduces a dedicated `nginx/Dockerfile`.

This Dockerfile uses the lightweight `nginx:1.23-alpine` image and copies the configuration directly into the image.

The `docker-compose.yml` has been updated to build this image instead of pulling one.

This approach has several benefits:
- It resolves the persistent volume mounting errors encountered in Portainer.
- It creates an immutable, self-contained production artifact.
- It uses a smaller, more secure base image (`alpine`).
- It simplifies the `docker-compose.yml` file.

Thanks to the user for suggesting this superior solution.