### PR TITLE
feat: Add preprocessing preview feature

### DIFF
--- a/backend/app/api/preview.py
+++ b/backend/app/api/preview.py
@@ -1,0 +1,63 @@
+import json
+from flask import Blueprint, request, jsonify
+
+from ..utils.image_utils import read_image_from_bytes, encode_image_to_base64
+from ..processing.preprocess import preprocess_image
+from ..schemas.models import AnalysisParameters
+
+preview_bp = Blueprint('preview', __name__)
+
+@preview_bp.route('/preprocess', methods=['POST'])
+def preprocess_preview():
+    """
+    Provides a preview of the image preprocessing step.
+    Accepts an image and preprocessing parameters, and returns the
+    resulting binary image without running the full analysis.
+    """
+    if 'image' not in request.files:
+        return jsonify({"error": "No image file provided"}), 400
+
+    image_file = request.files['image']
+    image_bytes = image_file.read()
+
+    try:
+        original_image = read_image_from_bytes(image_bytes)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+
+    # Load and merge parameters
+    try:
+        default_params = AnalysisParameters()
+        user_params_dict = json.loads(request.form.get('params', '{}'))
+
+        # Create a new model instance with updated parameters
+        # This works for both Pydantic v1 and v2
+        updated_params_dict = default_params.dict()
+        updated_params_dict.update(user_params_dict)
+        params = AnalysisParameters(**updated_params_dict)
+
+    except (json.JSONDecodeError, TypeError) as e:
+        return jsonify({"error": f"Invalid parameters: {str(e)}"}), 400
+
+    try:
+        # Perform only the preprocessing step
+        binary_image = preprocess_image(
+            original_image,
+            params.gaussian_sigma,
+            params.adaptive_block_size,
+            params.adaptive_offset,
+            params.morph_open_kernel,
+            params.area_opening_min_size_px
+        )
+
+        # Encode the result as base64
+        base64_image = encode_image_to_base64(binary_image)
+
+        return jsonify({
+            "preview_image_base64": base64_image
+        })
+
+    except Exception as e:
+        return jsonify({
+            "error": f"An error occurred during preprocessing: {str(e)}"
+        }), 500

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from flask_cors import CORS
 
 from .api.analysis import analysis_bp
 from .api.reports import reports_bp
+from .api.preview import preview_bp
 
 def create_app():
     """Create and configure an instance of the Flask application."""
@@ -16,6 +17,7 @@ def create_app():
     # Register blueprints
     app.register_blueprint(analysis_bp, url_prefix='/api')
     app.register_blueprint(reports_bp, url_prefix='/api')
+    app.register_blueprint(preview_bp, url_prefix='/api/preview')
 
     @app.route("/")
     def health_check():

--- a/backend/app/processing/preprocess.py
+++ b/backend/app/processing/preprocess.py
@@ -8,7 +8,7 @@ def preprocess_image(
     image: np.ndarray,
     gaussian_sigma: float = 1.0,
     adaptive_block_size: int = 101,
-    adaptive_offset: int = 10,
+    adaptive_offset: int = 2,
     morph_open_kernel: int = 3,
     area_opening_min_size_px: int = 500,
 ) -> np.ndarray:

--- a/frontend/src/components/PreprocessPanel.tsx
+++ b/frontend/src/components/PreprocessPanel.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import { Button } from '@/components/ui/button';
 
 interface PreprocessPanelProps {
     params: { [key: string]: any };
     onParamsChange: (newParams: { [key: string]: any }) => void;
+    onPreview: () => void;
+    isImageLoaded: boolean;
+    isPreviewing: boolean;
 }
 
-const PreprocessPanel: React.FC<PreprocessPanelProps> = ({ params, onParamsChange }) => {
+const PreprocessPanel: React.FC<PreprocessPanelProps> = ({ params, onParamsChange, onPreview, isImageLoaded, isPreviewing }) => {
 
     const handleParamChange = (key: string, value: number) => {
         onParamsChange({ ...params, [key]: value });
@@ -13,7 +17,7 @@ const PreprocessPanel: React.FC<PreprocessPanelProps> = ({ params, onParamsChang
 
   return (
     <div>
-      <h3 className="text-lg font-semibold mb-2">Preprocessing Parameters</h3>
+      <h3 className="text-lg font-semibold mb-2">2. Preprocessing Parameters</h3>
       <div className="space-y-4">
         <div>
           <label htmlFor="gaussian_sigma" className="flex justify-between text-sm font-medium">
@@ -55,6 +59,14 @@ const PreprocessPanel: React.FC<PreprocessPanelProps> = ({ params, onParamsChang
          />
         </div>
       </div>
+      <Button
+        variant="outline"
+        className="w-full mt-4"
+        onClick={onPreview}
+        disabled={!isImageLoaded || isPreviewing}
+      >
+        {isPreviewing ? 'Loading Preview...' : 'Preview Preprocessing'}
+      </Button>
     </div>
   );
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -70,3 +70,32 @@ export const getPdfReport = async (analysisResult: any) => {
         throw new Error('An unexpected error occurred.');
     }
 }
+
+/**
+ * Requests a preview of the preprocessing step from the backend.
+ * @param imageFile The image file to preprocess.
+ * @param params The preprocessing parameters.
+ * @returns An object containing the base64-encoded preview image.
+ */
+export const getPreprocessingPreview = async (
+  imageFile: File,
+  params: AnalysisParams
+) => {
+  const formData = new FormData();
+  formData.append('image', imageFile);
+  formData.append('params', JSON.stringify(params));
+
+  try {
+    const response = await apiClient.post('/preview/preprocess', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return response.data; // Should be { preview_image_base64: string }
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.error || 'An unknown error occurred during preview.');
+    }
+    throw new Error('An unexpected error occurred.');
+  }
+};


### PR DESCRIPTION
This commit introduces a new feature that allows users to get a real-time preview of the image preprocessing step. This is crucial for correctly tuning the preprocessing parameters to ensure accurate grain boundary detection.

This feature was implemented in response to user feedback that the skeletonization was failing due to poorly tuned parameters, and the feedback loop was too slow.

Key changes:
- **Backend:** A new endpoint `/api/preview/preprocess` has been added. It takes an image and parameters and returns a base64-encoded binary image showing the result of the preprocessing.
- **Frontend:**
    - A "Preview Preprocessing" button has been added to the UI.
    - A new API client and `useMutation` hook handle calling the preview endpoint.
    - The canvas now displays the preview image when available, providing instant feedback.
- **Algorithm Improvement:** The default `adaptive_offset` parameter for thresholding has been changed from 10 to 2, providing a much more sensitive and effective default for typical images.