### PR TITLE
fix(frontend): Correct data URI construction for preview image

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,7 +68,8 @@ function MainApp() {
       return getPreprocessingPreview(imageFile, params);
     },
     onSuccess: (data) => {
-      setPreviewImage(`data:image/png;base64,${data.preview_image_base64}`);
+      // The backend already returns the full data URI string
+      setPreviewImage(data.preview_image_base64);
     },
     onError: (error: Error) => {
       setAnalysisError(error.message);


### PR DESCRIPTION
This commit fixes a bug in the new preprocessing preview feature that caused an `ERR_INVALID_URL` error in the browser.

The error was caused by the frontend adding a `data:image/png;base64,` prefix to a string that already contained it. The backend utility function `encode_image_to_base64` was already returning the full data URI.

The fix removes the redundant prefix concatenation in the `onSuccess` handler of the `previewMutation` in `App.tsx`.