### PR TITLE
fix(backend): Unify parameter handling in analysis endpoint

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -31,12 +31,18 @@ def analyze_image():
         return jsonify({"error": str(e)}), 400
 
     # Load and merge parameters
-    default_params = AnalysisParameters()
     try:
-        user_params = json.loads(request.form.get('params', '{}'))
-        params = default_params.model_copy(update=user_params)
-    except json.JSONDecodeError:
-        return jsonify({"error": "Invalid JSON in params field"}), 400
+        default_params = AnalysisParameters()
+        user_params_dict = json.loads(request.form.get('params', '{}'))
+
+        # Create a new model instance with updated parameters
+        # This works for both Pydantic v1 and v2
+        updated_params_dict = default_params.dict()
+        updated_params_dict.update(user_params_dict)
+        params = AnalysisParameters(**updated_params_dict)
+
+    except (json.JSONDecodeError, TypeError) as e:
+        return jsonify({"error": f"Invalid parameters: {str(e)}"}), 400
 
     pixel_size_um = float(request.form.get('pixel_size_um', 1.0))
     if pixel_size_um <= 0:


### PR DESCRIPTION
This commit fixes a critical bug where the final analysis was not using the same parameters as the preprocessing preview.

The preview endpoint and the analysis endpoint were using slightly different logic to merge default parameters with user-provided parameters. This caused the user's tuned settings from the preview to be ignored during the final analysis, leading to inconsistent and incorrect results.

The parameter handling logic from the working preview endpoint has been applied to the main analysis endpoint to ensure they behave identically.