### PR TITLE
feat(frontend): Add UI control for skeleton pruning

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,9 +35,9 @@ function MainApp() {
     gaussian_sigma: 1.0,
     adaptive_block_size: 101,
     adaptive_offset: 2,
-    // Add other preprocess params with defaults if they don't exist
     morph_open_kernel: 3,
     area_opening_min_size_px: 500,
+    skeleton_prune_ratio: 0.5,
   });
   const [analysisResult, setAnalysisResult] = useState<AnalysisResult>(null);
   const [analysisError, setAnalysisError] = useState<string | null>(null);

--- a/frontend/src/components/PreprocessPanel.tsx
+++ b/frontend/src/components/PreprocessPanel.tsx
@@ -17,8 +17,9 @@ const PreprocessPanel: React.FC<PreprocessPanelProps> = ({ params, onParamsChang
 
   return (
     <div>
-      <h3 className="text-lg font-semibold mb-2">2. Preprocessing Parameters</h3>
-      <div className="space-y-4">
+      <h3 className="text-lg font-semibold mb-2">2. Analysis Parameters</h3>
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-muted-foreground">Preprocessing</p>
         <div>
           <label htmlFor="gaussian_sigma" className="flex justify-between text-sm font-medium">
             <span>Gaussian Sigma</span>
@@ -67,6 +68,22 @@ const PreprocessPanel: React.FC<PreprocessPanelProps> = ({ params, onParamsChang
       >
         {isPreviewing ? 'Loading Preview...' : 'Preview Preprocessing'}
       </Button>
+      <div className="space-y-2 mt-4 pt-4 border-t">
+        <p className="text-sm font-medium text-muted-foreground">Skeletonization</p>
+        <div>
+          <label htmlFor="skeleton_prune_ratio" className="flex justify-between text-sm font-medium">
+            <span>Skeleton Prune Ratio</span>
+            <span>{params.skeleton_prune_ratio}</span>
+          </label>
+          <input
+            type="range" id="skeleton_prune_ratio"
+            min="0" max="1" step="0.05"
+            value={params.skeleton_prune_ratio}
+            onChange={(e) => handleParamChange('skeleton_prune_ratio', parseFloat(e.target.value))}
+            className="w-full"
+         />
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
This commit exposes the `skeleton_prune_ratio` parameter in the UI, allowing the user to control the aggressiveness of the skeleton pruning algorithm.

This was implemented in response to user feedback that the skeletonization results did not match the quality of the preprocessed image, suggesting the default pruning was too aggressive.

The "Preprocessing Parameters" panel has been renamed to "Analysis Parameters" and now includes a slider for this new setting.