### PR TITLE
feat: Add final geometry count to debug panel

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -138,6 +138,7 @@ def analyze_image():
     edge_geometries = [
         {'coords': np.fliplr(d['coords']).tolist()} for _, _, d in pruned_graph.edges(data=True) if 'coords' in d
     ]
+    debug_stats.edge_geometries_count = len(edge_geometries)
     edge_stats = EdgeStats(
         n_nodes=pruned_graph.number_of_nodes(),
         n_edges=pruned_graph.number_of_edges(),

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -82,6 +82,7 @@ class DebugStats(BaseModel):
     edges_before_pruning: int
     nodes_after_pruning: int
     edges_after_pruning: int
+    edge_geometries_count: int
 
 
 class AnalysisResult(BaseModel):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ type AnalysisResult = {
     edges_before_pruning: number;
     nodes_after_pruning: number;
     edges_after_pruning: number;
+    edge_geometries_count: number;
   };
   // other fields...
 } | null;

--- a/frontend/src/components/DebugPanel.tsx
+++ b/frontend/src/components/DebugPanel.tsx
@@ -13,6 +13,7 @@ interface DebugStats {
     edges_before_pruning: number;
     nodes_after_pruning: number;
     edges_after_pruning: number;
+    edge_geometries_count: number;
 }
 
 interface DebugPanelProps {
@@ -38,6 +39,7 @@ const DebugPanel: React.FC<DebugPanelProps> = ({ debugOverlays, debugStats }) =>
                         <li>Edges before pruning: {debugStats.edges_before_pruning}</li>
                         <li className="pt-1 border-t border-muted-foreground/20">Nodes after pruning:  {debugStats.nodes_after_pruning}</li>
                         <li>Edges after pruning:  {debugStats.edges_after_pruning}</li>
+                        <li className="pt-1 border-t border-destructive/20 text-destructive">Edges sent to frontend: {debugStats.edge_geometries_count}</li>
                     </ul>
                 </div>
             )}


### PR DESCRIPTION
This commit adds the final piece of diagnostic information to the debug console: the count of edge geometries that are calculated and sent to the frontend for rendering.

This is in response to a bug where the final skeleton is not rendered correctly, despite the graph statistics appearing healthy. This new stat will definitively isolate the bug to either the backend's geometry creation or the frontend's rendering logic.