### PR TITLE
revert: Revert incorrect coordinate system fix

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -128,7 +128,7 @@ def analyze_image():
     # Edge Stats & Geometry
     edge_lengths = [d['length'] for _, _, d in pruned_graph.edges(data=True)]
     edge_geometries = [
-        {'coords': d['coords'].tolist()} for _, _, d in pruned_graph.edges(data=True) if 'coords' in d
+        {'coords': np.fliplr(d['coords']).tolist()} for _, _, d in pruned_graph.edges(data=True) if 'coords' in d
     ]
 
     # Create debug stats object now that all stats are calculated

--- a/backend/app/processing/intersections.py
+++ b/backend/app/processing/intersections.py
@@ -26,8 +26,9 @@ def detect_and_cluster_intersections(
         # coords from skan are (row, col) -> (y, x)
         coords = data.get('coords')
         if coords is not None and len(coords) >= 2:
-            # The coordinates are assumed to be in (x, y) format already.
-            all_edges.append(LineString(coords))
+            # Shapely expects (x, y), so we must flip the columns of the coordinate array
+            coords_xy = np.fliplr(coords)
+            all_edges.append(LineString(coords_xy))
 
     skeleton_multiline = MultiLineString(all_edges)
 


### PR DESCRIPTION
This reverts the previous commit that removed the `np.fliplr()` calls from the backend.

User feedback confirmed that removing the flip caused the rendered skeleton to move off the grain boundaries, proving that the `(y, x)` to `(x, y)` transformation was correct and necessary.

This change restores the code to its most stable known state. While a subtle bug still exists where the final metrics are zero, this version correctly handles the coordinate systems.