### PR TITLE
feat: Add pruned graph image to debug panel

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -5,7 +5,7 @@ import numpy as np
 from flask import Blueprint, request, jsonify
 
 from ..schemas.models import AnalysisParameters, AnalysisResult, EdgeStats, Timings, Overlays, DebugOverlays, DebugStats
-from ..utils.image_utils import read_image_from_bytes, encode_image_to_base64, create_overlay_image
+from ..utils.image_utils import read_image_from_bytes, encode_image_to_base64, create_overlay_image, draw_graph_on_image
 from ..processing.preprocess import preprocess_image
 from ..processing.skeleton import skeletonize_image, estimate_border_width
 from ..processing.graph import build_graph_from_skeleton, prune_graph
@@ -119,10 +119,15 @@ def analyze_image():
 
     # --- Assemble Response ---
 
+    # Draw the pruned graph for debugging
+    pruned_graph_image = draw_graph_on_image(pruned_graph, original_image.shape)
+    debug_pruned_graph_base64 = encode_image_to_base64(pruned_graph_image)
+
     # Create debug overlays object
     debug_overlays = DebugOverlays(
         binary_image_base64=debug_binary_base64,
         skeleton_image_base64=debug_skeleton_base64,
+        pruned_graph_image_base64=debug_pruned_graph_base64,
     )
 
     # Edge Stats & Geometry

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -72,6 +72,7 @@ class DebugOverlays(BaseModel):
     """
     binary_image_base64: str
     skeleton_image_base64: str
+    pruned_graph_image_base64: str
 
 
 class DebugStats(BaseModel):

--- a/backend/app/utils/image_utils.py
+++ b/backend/app/utils/image_utils.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import cv2
+import networkx as nx
 import numpy as np
 from PIL import Image
 
@@ -89,3 +90,23 @@ def create_overlay_image(
             cv2.circle(overlay, center, radius=8, color=(0,0,0), thickness=2) # Black outline
 
     return overlay
+
+
+def draw_graph_on_image(graph: nx.Graph, image_shape: tuple) -> np.ndarray:
+    """
+    Draws the edges of a networkx graph onto a blank image.
+    This is useful for debugging the graph structure.
+    """
+    # Create a blank black image with 3 channels
+    image = np.zeros((image_shape[0], image_shape[1], 3), dtype=np.uint8)
+
+    # Iterate through the edges and draw them
+    for _, _, data in graph.edges(data=True):
+        coords = data.get('coords')
+        if coords is not None and len(coords) >= 2:
+            # The `coords` from skan are (row, col) which is (y, x).
+            # cv2.polylines expects points as (x, y), so we need to flip.
+            points = np.fliplr(coords).astype(np.int32).reshape((-1, 1, 2))
+            cv2.polylines(image, [points], isClosed=False, color=(0, 255, 0), thickness=1)
+
+    return image

--- a/frontend/src/components/DebugPanel.tsx
+++ b/frontend/src/components/DebugPanel.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 interface DebugOverlays {
     binary_image_base64: string;
     skeleton_image_base64: string;
+    pruned_graph_image_base64: string;
 }
 
 interface DebugStats {
@@ -46,9 +47,9 @@ const DebugPanel: React.FC<DebugPanelProps> = ({ debugOverlays, debugStats }) =>
 
             {/* Image Overlays */}
             {debugOverlays && (
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div>
-                        <h3 className="text-md font-medium text-center mb-2">Preprocessing Result (Binary)</h3>
+                        <h3 className="text-md font-medium text-center mb-2">1. Preprocessing Result</h3>
                         <img
                             src={debugOverlays.binary_image_base64}
                             alt="Preprocessing Result"
@@ -56,10 +57,18 @@ const DebugPanel: React.FC<DebugPanelProps> = ({ debugOverlays, debugStats }) =>
                         />
                     </div>
                     <div>
-                        <h3 className="text-md font-medium text-center mb-2">Raw Skeleton</h3>
+                        <h3 className="text-md font-medium text-center mb-2">2. Raw Skeleton</h3>
                         <img
                             src={debugOverlays.skeleton_image_base64}
                             alt="Raw Skeleton"
+                            className="w-full h-auto border rounded-md"
+                        />
+                    </div>
+                    <div>
+                        <h3 className="text-md font-medium text-center mb-2">3. Final Graph</h3>
+                        <img
+                            src={debugOverlays.pruned_graph_image_base64}
+                            alt="Final Pruned Graph"
                             className="w-full h-auto border rounded-md"
                         />
                     </div>


### PR DESCRIPTION
This commit adds a new visualization to the debugging panel to help diagnose the final bug in the analysis pipeline.

At the user's request, the application now generates and displays an image of the final, pruned graph. This allows for a direct visual comparison between the raw skeleton and the graph structure that is actually used for metric calculations.

This should provide the final piece of evidence needed to understand why the final results are incorrect.