### PR TITLE
Feat(backend): Add debugging for graph drawing

### DIFF
--- a/backend/app/utils/image_utils.py
+++ b/backend/app/utils/image_utils.py
@@ -101,12 +101,22 @@ def draw_graph_on_image(graph: nx.Graph, image_shape: tuple) -> np.ndarray:
     image = np.zeros((image_shape[0], image_shape[1], 3), dtype=np.uint8)
 
     # Iterate through the edges and draw them
-    for _, _, data in graph.edges(data=True):
+    # Define a list of distinct BGR colors
+    colors = [
+        (0, 0, 255),   # Red
+        (0, 255, 0),   # Green
+        (255, 0, 0),   # Blue
+        (0, 255, 255), # Yellow
+        (255, 0, 255), # Magenta
+        (255, 255, 0)  # Cyan
+    ]
+    for i, (_, _, data) in enumerate(graph.edges(data=True)):
         coords = data.get('coords')
         if coords is not None and len(coords) >= 2:
             # The graph now stores coords in (x, y) format.
             # cv2.polylines expects points as (x, y).
             points = np.array(coords, dtype=np.int32).reshape((-1, 1, 2))
-            cv2.polylines(image, [points], isClosed=False, color=(0, 255, 0), thickness=1)
+            color = colors[i % len(colors)]
+            cv2.polylines(image, [points], isClosed=False, color=color, thickness=1)
 
     return image


### PR DESCRIPTION
This commit includes two changes to help diagnose and fix an issue where the final graph is reportedly rendered as a single line:

1.  The pruning algorithm in `graph.py` is made more robust by using the median edge length instead of the mean. This should prevent overly aggressive pruning.
2.  The `draw_graph_on_image` utility in `image_utils.py` is modified to cycle through a list of distinct colors when drawing graph edges. This will help visually determine if multiple edges are being drawn correctly or if they are being drawn on top of each other.