### PR TITLE
Fix(backend): Fix bug causing all graph edges to share the same coord…

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -137,17 +137,12 @@ def analyze_image():
     ]
 
     # Create debug stats object now that all stats are calculated
-    edges_before_coords = [str(d.get('coords', 'N/A').tolist()) for _, _, d in graph.edges(data=True)]
-    edges_after_coords = [str(d.get('coords', 'N/A').tolist()) for _, _, d in pruned_graph.edges(data=True)]
-
     debug_stats = DebugStats(
         nodes_before_pruning=nodes_before,
         edges_before_pruning=edges_before,
         nodes_after_pruning=nodes_after,
         edges_after_pruning=edges_after,
-        edge_geometries_count=len(edge_geometries),
-        edges_before_pruning_coords=edges_before_coords,
-        edges_after_pruning_coords=edges_after_coords
+        edge_geometries_count=len(edge_geometries)
     )
 
     edge_stats = EdgeStats(

--- a/backend/app/processing/graph.py
+++ b/backend/app/processing/graph.py
@@ -51,7 +51,7 @@ def build_graph_from_skeleton(skeleton: np.ndarray):
                 v,
                 id=int(row['skeleton-id']),
                 length=row['branch-distance'],
-                coords=path_coords_xy # Stored as (x, y)
+                coords=path_coords_xy.copy() # Stored as (x, y)
             )
 
     return G, summary

--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -84,8 +84,6 @@ class DebugStats(BaseModel):
     nodes_after_pruning: int
     edges_after_pruning: int
     edge_geometries_count: int
-    edges_before_pruning_coords: Optional[List[str]] = None
-    edges_after_pruning_coords: Optional[List[str]] = None
 
 
 class AnalysisResult(BaseModel):

--- a/frontend/src/components/DebugPanel.tsx
+++ b/frontend/src/components/DebugPanel.tsx
@@ -15,8 +15,6 @@ interface DebugStats {
     nodes_after_pruning: number;
     edges_after_pruning: number;
     edge_geometries_count: number;
-    edges_before_pruning_coords?: string[];
-    edges_after_pruning_coords?: string[];
 }
 
 interface DebugPanelProps {
@@ -47,27 +45,9 @@ const DebugPanel: React.FC<DebugPanelProps> = ({ debugOverlays, debugStats }) =>
                 </div>
             )}
 
-            {/* Coordinate Consoles */}
-            {debugStats?.edges_before_pruning_coords && (
-                <details className="mt-4">
-                    <summary className="cursor-pointer text-md font-medium">Raw Skeleton Edge Coordinates ({debugStats.edges_before_pruning_coords.length})</summary>
-                    <pre className="mt-2 p-2 bg-muted/50 rounded-lg text-xs overflow-auto max-h-48 font-mono">
-                        {debugStats.edges_before_pruning_coords.join('\n')}
-                    </pre>
-                </details>
-            )}
-            {debugStats?.edges_after_pruning_coords && (
-                <details className="mt-2">
-                    <summary className="cursor-pointer text-md font-medium">Final Graph Edge Coordinates ({debugStats.edges_after_pruning_coords.length})</summary>
-                    <pre className="mt-2 p-2 bg-muted/50 rounded-lg text-xs overflow-auto max-h-48 font-mono">
-                        {debugStats.edges_after_pruning_coords.join('\n')}
-                    </pre>
-                </details>
-            )}
-
             {/* Image Overlays */}
             {debugOverlays && (
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-4">
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div>
                         <h3 className="text-md font-medium text-center mb-2">1. Preprocessing Result</h3>
                         <img


### PR DESCRIPTION
…inates

The root cause of the graph rendering issue has been identified and fixed. Due to the way networkx handles attribute assignment and how numpy arrays are referenced, every edge in the constructed graph was being assigned a reference to the same coordinate array object. This resulted in a graph where all 500+ edges had identical geometry, making it appear as a single line.

This commit resolves the issue by creating a deep copy of the coordinate array for each edge using `.copy()` before adding it to the graph. This ensures each edge has its own unique geometric data.

This fix is based on direct evidence from the user-provided coordinate data, which showed all edge coordinates were identical.