### PR TITLE
Feat(debug): Add edge IDs to coordinate console

### DIFF
--- a/backend/app/api/analysis.py
+++ b/backend/app/api/analysis.py
@@ -137,8 +137,14 @@ def analyze_image():
     ]
 
     # Create debug stats object now that all stats are calculated
-    edges_before_coords = [str(d.get('coords', 'N/A').tolist()) for _, _, d in graph.edges(data=True)]
-    edges_after_coords = [str(d.get('coords', 'N/A').tolist()) for _, _, d in pruned_graph.edges(data=True)]
+    edges_before_coords = [
+        f"ID: {d.get('id', 'N/A')}, Coords: {str(d.get('coords', 'N/A').tolist())}"
+        for _, _, d in graph.edges(data=True)
+    ]
+    edges_after_coords = [
+        f"ID: {d.get('id', 'N/A')}, Coords: {str(d.get('coords', 'N/A').tolist())}"
+        for _, _, d in pruned_graph.edges(data=True)
+    ]
 
     debug_stats = DebugStats(
         nodes_before_pruning=nodes_before,


### PR DESCRIPTION
This commit enhances the debugging console to provide more insight into the graph construction process.

The coordinate display for the raw and pruned graphs in the debug panel will now also include the unique `id` for each edge. This will allow us to verify if the graph construction loop is processing unique edges or reusing the same edge repeatedly.

This is the final diagnostic step to understand the root cause of the graph rendering bug.