### PR TITLE
debug: Add exception to test motif generation call

### DIFF
--- a/backend/app/processing/motifs.py
+++ b/backend/app/processing/motifs.py
@@ -20,6 +20,7 @@ def generate_motifs(image_shape: tuple, params: Dict[str, Any], seed: int) -> Li
 
 
 def _generate_linear_motifs(image_shape: tuple, params: Dict[str, Any], rng) -> List[Dict[str, Any]]:
+    raise ValueError("--- MOTIF DEBUG: I was called! ---")
     print(f"--- MOTIF DEBUG: Starting motif generation ---", file=sys.stderr, flush=True)
     motifs = []
     h, w = image_shape


### PR DESCRIPTION
This commit adds a `ValueError` that is intentionally raised at the start of the `_generate_linear_motifs` function.

This is a debugging measure to definitively test whether this function is being called during the analysis pipeline. The presence of the `ValueError` traceback in the `backend_error.log` will confirm that the function is on the execution path.