### PR TITLE
debug: Add log-to-exception mechanism in motif generation

### DIFF
--- a/backend/app/processing/motifs.py
+++ b/backend/app/processing/motifs.py
@@ -20,50 +20,43 @@ def generate_motifs(image_shape: tuple, params: Dict[str, Any], seed: int) -> Li
 
 
 def _generate_linear_motifs(image_shape: tuple, params: Dict[str, Any], rng) -> List[Dict[str, Any]]:
-    raise ValueError("--- MOTIF DEBUG: I was called! ---")
-    print(f"--- MOTIF DEBUG: Starting motif generation ---", file=sys.stderr, flush=True)
+    debug_log = ["--- MOTIF DEBUG LOG ---"]
     motifs = []
     h, w = image_shape
-    print(f"MOTIF DEBUG: Image shape (h, w) = ({h}, {w})", file=sys.stderr, flush=True)
-    print(f"MOTIF DEBUG: Received params = {params}", file=sys.stderr, flush=True)
+    debug_log.append(f"Image shape (h, w) = ({h}, {w})")
+    debug_log.append(f"Received params = {params}")
 
     count = params.get("count", 10)
     length_px = params.get("length_px", min(h, w) * 0.8)
     orientations = params.get("orientations", [0, 45, 90, 135])
-    print(f"MOTIF DEBUG: Using count={count}, length_px={length_px}, orientations={orientations}", file=sys.stderr, flush=True)
+    debug_log.append(f"Using count={count}, length_px={length_px}, orientations={orientations}")
 
     for i in range(count):
-        print(f"\nMOTIF DEBUG: Iteration {i}", file=sys.stderr, flush=True)
+        debug_log.append(f"\n--- Iteration {i} ---")
         # Choose a random orientation
         angle_deg = rng.choice(orientations)
         angle_rad = np.deg2rad(angle_deg)
-        print(f"MOTIF DEBUG: angle_deg={angle_deg}", file=sys.stderr, flush=True)
+        debug_log.append(f"angle_deg={angle_deg}")
 
         # Define a safe area for the center of the line to be generated
-        # This prevents the line from starting too close to the edge.
-        # A simple padding is more robust than complex trigonometric buffers.
         pad_x = w * 0.1
         pad_y = h * 0.1
-
-        # Ensure the range is valid, especially for very thin images
         low_x, high_x = pad_x, w - pad_x
         low_y, high_y = pad_y, h - pad_y
 
         if low_x >= high_x or low_y >= high_y:
-            # Fallback to center if padding is too large for image dimensions
             center_x, center_y = w/2, h/2
         else:
             center_x = rng.uniform(low_x, high_x)
             center_y = rng.uniform(low_y, high_y)
-        print(f"MOTIF DEBUG: center_x={center_x}, center_y={center_y}", file=sys.stderr, flush=True)
+        debug_log.append(f"center_x={center_x}, center_y={center_y}")
 
         # Calculate start and end points
         dx = (length_px / 2) * np.cos(angle_rad)
         dy = (length_px / 2) * np.sin(angle_rad)
-
         x1, y1 = center_x - dx, center_y - dy
         x2, y2 = center_x + dx, center_y + dy
-        print(f"MOTIF DEBUG: line points (x1,y1) to (x2,y2) = ({x1},{y1}) to ({x2},{y2})", file=sys.stderr, flush=True)
+        debug_log.append(f"line points (x1,y1) to (x2,y2) = ({x1},{y1}) to ({x2},{y2})")
 
         # Clip line to image boundaries to be safe
         line = LineString([(x1, y1), (x2, y2)])
@@ -71,16 +64,14 @@ def _generate_linear_motifs(image_shape: tuple, params: Dict[str, Any], rng) -> 
         clipped_line = line.intersection(bounds.buffer(0.1))
 
         if clipped_line.is_empty or not isinstance(clipped_line, LineString):
-            print(f"MOTIF DEBUG: Clipped line is empty or not a LineString. Skipping.", file=sys.stderr, flush=True)
+            debug_log.append(f"Skipping: Clipped line is empty or not a LineString. Type is {type(clipped_line)}")
             continue
 
         final_coords = list(clipped_line.coords)
-        print(f"MOTIF DEBUG: Clipped line has {len(final_coords)} points.", file=sys.stderr, flush=True)
+        debug_log.append(f"Clipped line has {len(final_coords)} points.")
 
-        # A valid LineString requires at least two points. Clipping can reduce a
-        # line to a single point or nothing.
         if len(final_coords) < 2:
-            print(f"MOTIF DEBUG: Not enough points in clipped line. Skipping.", file=sys.stderr, flush=True)
+            debug_log.append(f"Skipping: Not enough points in clipped line.")
             continue
 
         motifs.append({
@@ -89,9 +80,12 @@ def _generate_linear_motifs(image_shape: tuple, params: Dict[str, Any], rng) -> 
             "geometry": LineString(final_coords),
             "length_px": clipped_line.length
         })
-        print(f"MOTIF DEBUG: Successfully created motif {i}.", file=sys.stderr, flush=True)
+        debug_log.append(f"OK: Successfully created motif {i}.")
 
-    print(f"--- MOTIF DEBUG: Finished. Generated {len(motifs)} motifs. ---", file=sys.stderr, flush=True)
+    if not motifs:
+        # If we're about to return an empty list, raise an exception with the debug log.
+        raise ValueError("Failed to generate any valid motifs. Log:\n" + "\n".join(debug_log))
+
     return motifs
 
 


### PR DESCRIPTION
This commit implements a new debugging strategy for the persistent motif generation issue.

Standard logging to stderr was not appearing in the container logs. This change removes the `print` statements and replaces them with a list that accumulates debug messages.

If the `_generate_linear_motifs` function fails to create any motifs, it will now raise a `ValueError` containing the entire detailed debug log. This will ensure the debug information is delivered to the user in the API error response, bypassing any issues with the container's log streaming.