### PR TITLE
debug: Add diagnostic line to overlay image

### DIFF
--- a/backend/app/utils/image_utils.py
+++ b/backend/app/utils/image_utils.py
@@ -89,6 +89,11 @@ def create_overlay_image(
             cv2.circle(overlay, center, radius=8, color=color, thickness=-1) # Filled circle
             cv2.circle(overlay, center, radius=8, color=(0,0,0), thickness=2) # Black outline
 
+    # --- DEBUGGING: Draw a hardcoded diagonal line to test the canvas ---
+    h, w, _ = overlay.shape
+    cv2.line(overlay, (0, 0), (w - 1, h - 1), (255, 255, 255), 2)
+
+
     return overlay
 
 


### PR DESCRIPTION
This commit reverts the debugging changes in `motifs.py` and adds a hardcoded diagonal line to the `create_overlay_image` function.

This is a diagnostic test to determine if the issue of the "black motif image" is due to a problem with the motif data itself or a fundamental problem with the OpenCV drawing function.

- If the diagonal line appears, the drawing canvas is working, and the problem lies with the motif data.
- If the image is still pure black, the problem is with the drawing process.