### PR TITLE
fix(analysis): Set correct default motifs for ASTM E112

### DIFF
--- a/backend/app/schemas/models.py
+++ b/backend/app/schemas/models.py
@@ -15,9 +15,8 @@ class AnalysisParameters(BaseModel):
     epsilon_factor: float = 1.0
     norm_profile: str = "ASTM"
     motifs: Dict[str, Any] = {
-        "type": "linear",
-        "count": 10,
-        "orientations": [0]
+        "type": "circular",
+        "count": 3
     }
     random_seed: int = 42
 

--- a/backend/app/utils/image_utils.py
+++ b/backend/app/utils/image_utils.py
@@ -89,11 +89,6 @@ def create_overlay_image(
             cv2.circle(overlay, center, radius=8, color=color, thickness=-1) # Filled circle
             cv2.circle(overlay, center, radius=8, color=(0,0,0), thickness=2) # Black outline
 
-    # --- DEBUGGING: Draw a hardcoded diagonal line to test the canvas ---
-    h, w, _ = overlay.shape
-    cv2.line(overlay, (0, 0), (w - 1, h - 1), (255, 255, 255), 2)
-
-
     return overlay
 
 


### PR DESCRIPTION
This commit corrects the root cause of the analysis failure by aligning the default motif generation with the user's requirement for the ASTM E112 intercepts method.

The previous default parameter was set to generate linear motifs, which was incorrect for the intended analysis and caused a cascade of issues, including the generation of an empty motif list.

This commit changes the default `motifs` parameter in the `AnalysisParameters` model to: `{"type": "circular", "count": 3}`

This ensures that, by default, the application generates the 3 concentric circles required for the ASTM E112 standard, which should allow the analysis and visualization to function as intended.

This also reverts a temporary debugging change that added a hardcoded line to the image overlay function.