### PR TITLE
fix(ui): Make logs panel always visible

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import SkeletonCanvas from "@/components/SkeletonCanvas"
 import ResultsTable from "@/components/ResultsTable"
 import HistogramCard from "@/components/HistogramCard"
 import DebugPanel from "@/components/DebugPanel"
+import { LogsPanel } from "@/components/LogsPanel"
 
 const queryClient = new QueryClient();
 
@@ -160,6 +161,7 @@ function MainApp() {
                   </div>
                 )}
               </div>
+              <LogsPanel />
             </div>
 
             <div className="lg:col-span-2 space-y-6">

--- a/frontend/src/components/DebugPanel.tsx
+++ b/frontend/src/components/DebugPanel.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import { LogsPanel } from './LogsPanel';
-
 // Define the types for the debug data props
 interface DebugOverlays {
     binary_image_base64: string;
@@ -84,10 +82,6 @@ const DebugPanel: React.FC<DebugPanelProps> = ({ debugOverlays, debugStats }) =>
                 </div>
             )}
 
-            {/* Container Logs Panel */}
-            <div className="mt-4">
-                <LogsPanel />
-            </div>
         </div>
     );
 };


### PR DESCRIPTION
This commit refactors the UI to address a design flaw where the container log viewer was only visible after a successful analysis. This made it impossible to view logs when the analysis itself crashed.

- The `LogsPanel` component is removed from the `DebugPanel`.
- The `LogsPanel` is now placed directly in `App.tsx` in the main control column, ensuring it is always visible and accessible, regardless of the analysis state.